### PR TITLE
make use of requests params attribute

### DIFF
--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -278,7 +278,9 @@ class PlentyApi():
                                        date_type=date_type)
         if refine:
             invalid_keys = set(refine.keys()).difference(VALID_ORDER_REFINE_KEYS)
-            print(f"Invalid keys for the refine argument: {invalid_keys}")
+            print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+            for invalid_key in invalid_keys:
+                refine.pop(invalid_key, None)
             query.update(refine)
         if additional:
             query.update({'with': additional})
@@ -355,7 +357,9 @@ class PlentyApi():
 
         if refine:
             invalid_keys = set(refine.keys()).difference(VALID_ITEM_REFINE_KEYS)
-            print(f"Invalid keys for the refine argument: {invalid_keys}")
+            print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+            for invalid_key in invalid_keys:
+                refine.pop(invalid_key, None)
             query.update(refine)
 
         if additional:

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -25,6 +25,19 @@ import simplejson
 import plenty_api.keyring
 import plenty_api.utils as utils
 
+VALID_ORDER_REFINE_KEYS = {
+    'orderType', 'contactId', 'referrerId', 'shippingProfileId',
+    'shippingServiceProviderId', 'ownerUserId', 'warehouseId',
+    'isEbayPlus', 'includedVariation', 'includedItem', 'orderIds',
+    'countryId', 'orderItemName', 'variationNumber', 'sender.contact',
+    'sender.warehouse', 'receiver.contact', 'receiver.warehouse',
+    'externalOrderId', 'clientId', 'paymentStatus', 'statusFrom',
+    'statusTo', 'hasDocument', 'hasDocumentNumber', 'parentOrderId'
+}
+VALID_ITEM_REFINE_KEYS = {
+    'name', 'manfacturerId', 'id', 'flagOne', 'flagTwo'
+}
+
 
 class PlentyApi():
     """
@@ -252,6 +265,7 @@ class PlentyApi():
             Return:
                 [JSON(Dict) / DataFrame] <= self.data_format
         """
+
         date_range = utils.build_date_range(start=start, end=end)
         if not date_range:
             print(f"ERROR: Invalid range {start} -> {end}")
@@ -263,6 +277,8 @@ class PlentyApi():
         query = utils.build_query_date(date_range=date_range,
                                        date_type=date_type)
         if refine:
+            invalid_keys = set(refine.keys()).difference(VALID_ORDER_REFINE_KEYS)
+            print(f"Invalid keys for the refine argument: {invalid_keys}")
             query.update(refine)
         if additional:
             query.update({'with': additional})
@@ -338,6 +354,8 @@ class PlentyApi():
         query = {}
 
         if refine:
+            invalid_keys = set(refine.keys()).difference(VALID_ITEM_REFINE_KEYS)
+            print(f"Invalid keys for the refine argument: {invalid_keys}")
             query.update(refine)
 
         if additional:

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -189,6 +189,7 @@ class PlentyApi():
         endpoint = utils.build_endpoint(url=self.url, route=route, path=path)
         if self.debug:
             print(f"DEBUG: Endpoint: {endpoint}")
+            print(f"DEBUG: Params: {query}")
         if method.lower() == 'get':
             raw_response = requests.get(endpoint, headers=self.creds,
                                         params=query)
@@ -278,10 +279,12 @@ class PlentyApi():
                                        date_type=date_type)
         if refine:
             invalid_keys = set(refine.keys()).difference(VALID_ORDER_REFINE_KEYS)
-            print(f"Invalid keys for the refine argument removed: {invalid_keys}")
-            for invalid_key in invalid_keys:
-                refine.pop(invalid_key, None)
+            if invalid_keys:
+                print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+                for invalid_key in invalid_keys:
+                    refine.pop(invalid_key, None)
             query.update(refine)
+
         if additional:
             query.update({'with': additional})
 
@@ -357,9 +360,10 @@ class PlentyApi():
 
         if refine:
             invalid_keys = set(refine.keys()).difference(VALID_ITEM_REFINE_KEYS)
-            print(f"Invalid keys for the refine argument removed: {invalid_keys}")
-            for invalid_key in invalid_keys:
-                refine.pop(invalid_key, None)
+            if invalid_keys:
+                print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+                for invalid_key in invalid_keys:
+                    refine.pop(invalid_key, None)
             query.update(refine)
 
         if additional:

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -25,19 +25,6 @@ import simplejson
 import plenty_api.keyring
 import plenty_api.utils as utils
 
-VALID_ORDER_REFINE_KEYS = {
-    'orderType', 'contactId', 'referrerId', 'shippingProfileId',
-    'shippingServiceProviderId', 'ownerUserId', 'warehouseId',
-    'isEbayPlus', 'includedVariation', 'includedItem', 'orderIds',
-    'countryId', 'orderItemName', 'variationNumber', 'sender.contact',
-    'sender.warehouse', 'receiver.contact', 'receiver.warehouse',
-    'externalOrderId', 'clientId', 'paymentStatus', 'statusFrom',
-    'statusTo', 'hasDocument', 'hasDocumentNumber', 'parentOrderId'
-}
-VALID_ITEM_REFINE_KEYS = {
-    'name', 'manfacturerId', 'id', 'flagOne', 'flagTwo'
-}
-
 
 class PlentyApi():
     """
@@ -169,7 +156,7 @@ class PlentyApi():
                              domain: str,
                              query: dict = None,
                              data: dict = None,
-                             path: str = '',) -> dict:
+                             path: str = '') -> dict:
         """
             Make a request to the PlentyMarkets API.
 
@@ -278,9 +265,10 @@ class PlentyApi():
         query = utils.build_query_date(date_range=date_range,
                                        date_type=date_type)
         if refine:
-            invalid_keys = set(refine.keys()).difference(VALID_ORDER_REFINE_KEYS)
+            invalid_keys = set(refine.keys()).difference(
+                utils.VALID_ORDER_REFINE_KEYS)
             if invalid_keys:
-                print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+                print(f"Invalid refine argument key removed: {invalid_keys}")
                 for invalid_key in invalid_keys:
                     refine.pop(invalid_key, None)
             query.update(refine)
@@ -359,9 +347,10 @@ class PlentyApi():
         query = {}
 
         if refine:
-            invalid_keys = set(refine.keys()).difference(VALID_ITEM_REFINE_KEYS)
+            invalid_keys = set(refine.keys()).difference(
+                utils.VALID_ITEM_REFINE_KEYS)
             if invalid_keys:
-                print(f"Invalid keys for the refine argument removed: {invalid_keys}")
+                print(f"Invalid refine argument key removed: {invalid_keys}")
                 for invalid_key in invalid_keys:
                     refine.pop(invalid_key, None)
             query.update(refine)

--- a/plenty_api/utils.py
+++ b/plenty_api/utils.py
@@ -25,19 +25,7 @@ import re
 import dateutil.parser
 import pandas
 
-VALID_ROUTES = ['/rest/orders', '/rest/items', '/rest/vat']
-VALID_ORDER_REFINE_KEYS = [
-    'orderType', 'contactId', 'referrerId', 'shippingProfileId',
-    'shippingServiceProviderId', 'ownerUserId', 'warehouseId',
-    'isEbayPlus', 'includedVariation', 'includedItem', 'orderIds',
-    'countryId', 'orderItemName', 'variationNumber', 'sender.contact',
-    'sender.warehouse', 'receiver.contact', 'receiver.warehouse',
-    'externalOrderId', 'clientId', 'paymentStatus', 'statusFrom',
-    'statusTo', 'hasDocument', 'hasDocumentNumber', 'parentOrderId'
-]
-VALID_ITEM_REFINE_KEYS = [
-    'name', 'manfacturerId', 'id', 'flagOne', 'flagTwo'
-]
+
 VALID_COUNTRY_MAP = {
     "DE": 1, "AT": 2, "BE": 3, "CH": 4, "CY": 5, "CZ": 6, "DK": 7, "ES": 8,
     "EE": 9, "FR": 10, "FI": 11, "GB": 12, "GR": 13, "HU": 14, "IT": 15,

--- a/plenty_api/utils.py
+++ b/plenty_api/utils.py
@@ -25,7 +25,7 @@ import re
 import dateutil.parser
 import pandas
 
-
+VALID_ROUTES = ['/rest/orders', '/rest/items', '/rest/vat']
 VALID_COUNTRY_MAP = {
     "DE": 1, "AT": 2, "BE": 3, "CH": 4, "CY": 5, "CZ": 6, "DK": 7, "ES": 8,
     "EE": 9, "FR": 10, "FI": 11, "GB": 12, "GR": 13, "HU": 14, "IT": 15,

--- a/plenty_api/utils.py
+++ b/plenty_api/utils.py
@@ -22,7 +22,6 @@ import getpass
 import datetime
 import time
 import re
-import urllib.parse
 import dateutil.parser
 import pandas
 
@@ -156,30 +155,7 @@ def get_language(lang: str) -> int:
         return -1
 
 
-def build_request_query(elements: list) -> str:
-    """
-        Combine different query elements and check the query format.
-
-        Parameter:
-            elements [list]     -   List of strings containing one or more
-                                    query sub-elements
-
-        Return:
-            [str]               -   Full query
-    """
-    query = ''
-    query = query.join(elements)
-
-    # Set the first character to '?' and search for invalid occurences
-    if re.search(r'\?', query):
-        print(f"WARNING: {query} -> found a '?' at position > 0")
-    if query:
-        query = '?' + query[1:]
-
-    return query
-
-
-def build_query_date(date_range: dict, date_type: str) -> str:
+def build_query_date(date_range: dict, date_type: str) -> dict:
     """
         Create a query for the API endpoint, with valid values from the
         PlentyMarkets API documentation:
@@ -198,9 +174,9 @@ def build_query_date(date_range: dict, date_type: str) -> str:
                                     {Creation, Payment, Change, Delivery}
 
         Return:
-            [str]               -   Date range in query format
+            [dict]               -   Date range in python dictionary
     """
-    query = ''
+    query = {}
     if not date_range or not date_type:
         print("ERROR: Both date type and date range required")
         return ''
@@ -208,36 +184,13 @@ def build_query_date(date_range: dict, date_type: str) -> str:
         print(f"ERROR: Invalid date type for query creation: {date_type}")
         return ''
     date_type = ORDER_DATE_ARGUMENTS[date_type.lower()]
-    query += str(f"&{date_type}AtFrom={date_range['start']}")
-    query += str(f"&{date_type}AtTo={date_range['end']}")
-    return urllib.parse.quote(query, safe='?,&,=')
+    query.update({f"{date_type}AtFrom": date_range['start']})
+    query.update({f"{date_type}AtTo": date_range['end']})
+
+    return query
 
 
-def build_query_attributes(domain: str,
-                           refine: dict = None,
-                           additional: list = None) -> str:
-    """
-            refine
-            additional [List]   -   List of additional query arguments
-                                    used with `&with=`
-    """
-    query = ''
-    if refine is None and additional is None:
-        return ''
-    if refine is not None:
-        for key, item in refine.items():
-            if key in VALID_ORDER_REFINE_KEYS and domain.lower() == 'orders':
-                query += str(f"&{key}={item}")
-            elif key in VALID_ITEM_REFINE_KEYS and domain.lower() == 'items':
-                query += str(f"&{key}={item}")
-    if additional is not None:
-        for argument in additional:
-            query += str(f"&with={argument}")
-
-    return urllib.parse.quote(query, safe='?,&,=')
-
-
-def build_endpoint(url: str, route: str, query: str) -> str:
+def build_endpoint(url: str, route: str, path: str = '') -> str:
     """
         Perform basic checks to ensure that a valid endpoint is used for the
         request. Query elements should be obtained by usind the
@@ -247,7 +200,7 @@ def build_endpoint(url: str, route: str, query: str) -> str:
         Parameter:
             url [String]        -   Base url of the plentymarkets API
             route [String]      -   Route part endpoint (e.g. /rest/items)
-            query [String]      -   Complete query
+            path [String]       -   Sub route part (e.g. /{item_id}/images)
 
         Parameter:
             [String]            -   complete endpoint
@@ -260,7 +213,7 @@ def build_endpoint(url: str, route: str, query: str) -> str:
         print(f"ERROR: invalid route, [{route}]")
         return ''
 
-    return url + route + query
+    return url + route + path
 
 
 def json_to_dataframe(json):

--- a/plenty_api/utils.py
+++ b/plenty_api/utils.py
@@ -26,6 +26,18 @@ import dateutil.parser
 import pandas
 
 VALID_ROUTES = ['/rest/orders', '/rest/items', '/rest/vat']
+VALID_ORDER_REFINE_KEYS = {
+    'orderType', 'contactId', 'referrerId', 'shippingProfileId',
+    'shippingServiceProviderId', 'ownerUserId', 'warehouseId',
+    'isEbayPlus', 'includedVariation', 'includedItem', 'orderIds',
+    'countryId', 'orderItemName', 'variationNumber', 'sender.contact',
+    'sender.warehouse', 'receiver.contact', 'receiver.warehouse',
+    'externalOrderId', 'clientId', 'paymentStatus', 'statusFrom',
+    'statusTo', 'hasDocument', 'hasDocumentNumber', 'parentOrderId'
+}
+VALID_ITEM_REFINE_KEYS = {
+    'name', 'manfacturerId', 'id', 'flagOne', 'flagTwo'
+}
 VALID_COUNTRY_MAP = {
     "DE": 1, "AT": 2, "BE": 3, "CH": 4, "CY": 5, "CZ": 6, "DK": 7, "ES": 8,
     "EE": 9, "FR": 10, "FI": 11, "GB": 12, "GR": 13, "HU": 14, "IT": 15,


### PR DESCRIPTION
Everything which the requests params attribute can handle (safe urlencoding, query questionmark ... ), i tried to pass in requests(params=). For the put request, there is no params and i added the path variable instead.

I tested most things, they work. Also the language and date query for the items endpoint have some basic functionality now.

We lost the validation around valide attributes for the refine paramater. That said they got silently removed anyways.

For the test i prepared a request object which i compared to the expected query string.