### PR TITLE
Hotfix: Fix UnboundLocalError within plenty_api_get_property_selections

### DIFF
--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -33,6 +33,7 @@
         * [post attribute names](#post-attribute-names)
         * [post attribute values](#post-attribute-values)
         * [post attribute value names](#post-attribute-value-names)
+        * [post property selection name](#create-property-selection)
     + [Order related data](#post-order-section)
         * [post redistribution (move stock from one warehouse to another)](#post-redistribution)
         * [create transaction](#post-transaction)
@@ -580,6 +581,20 @@ Return a POST request JSON response, if one of the requests fails return the err
 If the **value_id** field is not filled the method will return: `{'error': 'missing_parameter'}`.
 In case the language within the `lang` field of the JSON is invalid the method will return `{'error': 'invalid_language'}`.
 
+#### plenty_api_create_property_selection_name <a name=create-property-selection></a>
+
+Create a new name for an existing property selection value for the given language.
+
+[*Required parameter*]:
+
+The **property_id** parameter contains the Plentymarkets ID of a property for which a new selection name value is being added, the **lang** parameter contains a two letter abbreviation of the target language (for a list of valid values look here: [Language codes](https://developers.plentymarkets.com/en-gb/developers/main/rest-api-guides/getting-started.html#_language_codes)), and the **name** parameter contains the visible name for the selection name in the given language.
+
+[*Output format*]:
+
+Return a POST request JSON response, if one of the requests fails return the error message.
+If the **property_id**, **lang** or **name** field is not filled the method will return: `{'error': 'missing_parameter'}`.
+In case the language within the `lang` field of the JSON is invalid the method will return `{'error': 'invalid_language'}`.
+
 #### Orders <a name='post-oders-section'></a>
 
 #### plenty_api_create_redistribution <a name='post-redistribution'></a>
@@ -772,6 +787,10 @@ This route is used to book in/out all pending transactions of an order.
 [*Required parameter*]:
 
 The booking is performed for the order specified by the **order_id** parameter, which contains the integer ID of the order assigned by Plentymarkets. The optional **delivery_note** parameter can contain a delivery note document's identifier, that should be connected to the booking.
+
+[*Output format*]:
+
+Return a POST request JSON response, if one of the requests fails return the error message.
 
 [*Output format*]:
 

--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -14,6 +14,7 @@
         * [get attributes](#get-attributes)
         * [get prices](#get-prices)
         * [get manufacturers](#get-manufacturers)
+        * [get property selections](#get-property-selections)
     + [Tax related data](#get-taxes-section)
         * [get vat id mappings](#get-vat-mappings)
     + [Stock related data](#get-stock-section)
@@ -274,6 +275,24 @@ The dates are accepted in the following formats:
 There are currently two supported output formats: 'json' and 'dataframe'.  
 The 'json' format simply returns the raw response, without page information and with multiple pages combined into a single data structure.  
 The 'dataframe' format transforms that data structure into a pandas DataFrame, which contains subparts in json, that can be split further by the user application.
+
+---
+
+##### plenty_api_get_property_selections: <a name='get-property-selections'></a>
+
+Create a mapping of property IDs to the selection-values of the property with the ID of the selection and text values for all available languages.
+
+[*Optional parameter*]:
+
+The **refine** field can be used to reduce the request to a single property ID.
+example: refine={'propertyID': 123}
+
+[*Output format*]:
+
+There are currently two supported output formats: 'json' and 'dataframe'.  
+The 'json' format returns a dictionary of property IDs to its available selection values
+example: ```{1: {11: {'de': 'value_1', 'en': 'value_2'}}, 2: {12: {'de': 'value_3', 'en': 'value_4'}}}```
+The 'dataframe' format transforms that data structure into a pandas DataFrame.
 
 ---
 ---

--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -44,6 +44,8 @@
     + [Stock related data](#put-stock-section)
         * [book incoming quanity](#book-incoming)
         * [book outgoing quanity](#book-outgoing)
+    + [Item related data](#put-item-section)
+        * [update property selection name](#update-property-selection)
 - [Extra features](#extras)
 
 ### LOGIN <a name='login'></a>
@@ -874,6 +876,22 @@ By specifying a storage location ID within **location_id**, you can target a spe
 [*Output format*]:
 
 Return a POST request JSON response, if one of the requests fails return the error message.
+
+#### Items <a name='put-item-section'></a>
+
+#### plenty_api_update_property_selection_name <a name=update-property-selection></a>
+
+Update a property selection name via its name ID.
+
+[*Required parameter*]:
+
+The **nameId** from Plentymarkets needs to be given in order to identify the property selection name that will be updated. The **name** parameter describes the new name value.
+Please refer to the [Plentymarkets Dev documentation: REST API PUT transaction](https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/).
+
+[*Output format*]:
+
+Return a PUT request JSON response, if one of the requests fails return the error message.
+If the **name_id** or **name** field is not filled the method will return: `{'error': 'missing_parameter'}`.
 
 ### Extra features <a name=extras></a>
 

--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -896,8 +896,10 @@ Update a property selection name via its name ID.
 
 [*Required parameter*]:
 
-The **nameId** from Plentymarkets needs to be given in order to identify the property selection name that will be updated. The **name** parameter describes the new name value.
+The **name_id** from Plentymarkets needs to be given in order to identify the property selection name that will be updated. The **name** parameter describes the new name value.
 Please refer to the [Plentymarkets Dev documentation: REST API PUT transaction](https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/).
+
+**NOTE:** To get the name ID from PlentyMarkets use the function ```plenty_api_get_property_selection_names``` where the ```id``` of each entry represents the name ID of the selection feature in that language.
 
 [*Output format*]:
 

--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -15,6 +15,7 @@
         * [get prices](#get-prices)
         * [get manufacturers](#get-manufacturers)
         * [get property selections](#get-property-selections)
+        * [get property selections names](#get-property-selections-names)
     + [Tax related data](#get-taxes-section)
         * [get vat id mappings](#get-vat-mappings)
     + [Stock related data](#get-stock-section)
@@ -296,6 +297,16 @@ There are currently two supported output formats: 'json' and 'dataframe'.
 The 'json' format returns a dictionary of property IDs to its available selection values
 example: ```{1: {11: {'de': 'value_1', 'en': 'value_2'}}, 2: {12: {'de': 'value_3', 'en': 'value_4'}}}```
 The 'dataframe' format transforms that data structure into a pandas DataFrame.
+
+##### plenty_api_get_property_selections_names: <a name='get-property-selections-names'></a>
+
+Get all names of a specific selection_id, with additional data such as the nameId, which is needed for updating selection names.
+
+[*Output format*]:
+
+There are currently two supported output formats: 'json' and 'dataframe'.  
+The 'json' format simply returns the raw response, without page information and with multiple pages combined into a single data structure.  
+The 'dataframe' format transforms that data structure into a pandas DataFrame, which contains subparts in json, that can be split further by the user application.
 
 ---
 ---

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -70,6 +70,8 @@ class PlentyApi():
 
         **plenty_api_get_property_selections**
 
+        **plenty_api_get_property_selection_names**
+
         POST REQUESTS
         **plenty_api_set_image_availability**
 
@@ -885,6 +887,22 @@ class PlentyApi():
             return pandas.DataFrame(df_data, columns=columns)
 
         return selection_map
+
+    def plenty_api_get_property_selection_names(self, selection_id: int):
+        """
+        Get all names for the specific selection Id.
+
+        Parameter:
+            selection_id        [int]   -   Selection Id which the names will
+                                            be rturned for
+
+        Return:
+                        [JSON(Dict) / DataFrame] <= self.data_format
+        """
+        path = f"/selections/{selection_id}/names"
+        data = self.__plenty_api_generic_get(domain='v2property', path=path)
+
+        return data
 
 # POST REQUESTS
 

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -100,6 +100,8 @@ class PlentyApi():
         **plenty_api_book_incoming_items**
 
         **plenty_api_book_outgoing_items**
+
+        **plenty_api_update_property_selection_name**
     """
 
     def __init__(self, base_url: str, use_keyring: bool = True,
@@ -1429,4 +1431,24 @@ class PlentyApi():
         # TODO Error handling and introduce proper logging
         logging.debug(response)
 
+        return response
+
+    def plenty_api_update_property_selection_name(self, name_id: int,
+                                                  name: str) -> dict:
+        """
+        Update the property selection name for the given name Id.
+
+        Parameters:
+            name_id         [int]   -   Id of the name value that will be
+                                        changed
+            name            [str]   -   New name value
+        """
+        if not name_id or not name:
+            return {'error': 'missing_parameter'}
+
+        json = {'name': name}
+
+        path = f"/selections/names/{name_id}"
+        response = self.__plenty_api_request(method="put", path=path,
+                                             domain="v2property", data=json)
         return response

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -91,6 +91,8 @@ class PlentyApi():
 
         **plenty_api_create_booking**
 
+        **plenty_api_create_property_selection_name**
+
         PUT REQUESTS
 
         **plenty_api_update_redistribution**
@@ -1233,6 +1235,35 @@ class PlentyApi():
                                              domain="order",
                                              path=path,
                                              data=data)
+        return response
+
+
+    def plenty_api_create_property_selection_name(self, property_id: int,
+                                                  lang: str, name: str) -> dict:
+        """
+        Create a name in a specific language for a selection property.
+
+        Parameter:
+            property_id     [int]   -   Plentymarkets property Id which a new
+                                        selection namm will be created for
+            lang            [str]   -   Initial language for selection creation
+            name            [str]   -   Value of the selection name
+
+        Return:
+                            [dict]  -   Return the response object, in case the
+                                        request fails return an error message
+        """
+        if not property_id or not lang or not name:
+            return [{'error': 'missing_parameter'}]
+
+        if utils.get_language(lang=lang) == 'INVALID_LANGUAGE':
+            return {'error': 'invalid_language'}
+
+        json = {'propertyId': property_id, 'lang': lang, 'name': name,}
+
+        path = "/selections/names"
+        response = self.__plenty_api_request(method="post", path=path,
+                                             domain="v2property", data=json)
         return response
 
 # PUT REQUESTS

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -859,11 +859,11 @@ class PlentyApi():
         Return:
                         [dict]  -   Mapping of all selection property values
         """
-        domain='property',
-        path='/selections',
+        domain = 'property'
+        path = '/selections'
 
         query = utils.sanity_check_parameter(
-            domain=domain, query=query, refine=refine,
+            domain=domain, query=None, refine=refine,
             additional=None, lang='')
 
         data = self.__repeat_get_request_for_all_records(
@@ -1279,7 +1279,7 @@ class PlentyApi():
         if utils.get_language(lang=lang) == 'INVALID_LANGUAGE':
             return {'error': 'invalid_language'}
 
-        json = {'propertyId': property_id, 'lang': lang, 'name': name,}
+        json = {'propertyId': property_id, 'lang': lang, 'name': name}
 
         path = "/selections/names"
         response = self.__plenty_api_request(method="post", path=path,

--- a/plenty_api/constants.py
+++ b/plenty_api/constants.py
@@ -35,7 +35,8 @@ VALID_DOMAINS = [
     'variation',
     'vat',
     'warehouses',
-    'property'
+    'property',
+    'v2property'
 ]
 VALID_ROUTES = [
     '/rest/items/attributes',
@@ -50,7 +51,8 @@ VALID_ROUTES = [
     '/rest/items/variations',
     '/rest/vat',
     '/rest/stockmanagement/warehouses',
-    '/rest/properties'
+    '/rest/properties',
+    '/rest/v2/properties'
 ]
 DOMAIN_ROUTE_MAP = dict(zip(VALID_DOMAINS, VALID_ROUTES))
 

--- a/plenty_api/constants.py
+++ b/plenty_api/constants.py
@@ -34,7 +34,8 @@ VALID_DOMAINS = [
     'stockmanagement',
     'variation',
     'vat',
-    'warehouses'
+    'warehouses',
+    'property'
 ]
 VALID_ROUTES = [
     '/rest/items/attributes',
@@ -48,7 +49,8 @@ VALID_ROUTES = [
     '/rest/stockmanagement/stock',
     '/rest/items/variations',
     '/rest/vat',
-    '/rest/stockmanagement/warehouses'
+    '/rest/stockmanagement/warehouses',
+    '/rest/properties'
 ]
 DOMAIN_ROUTE_MAP = dict(zip(VALID_DOMAINS, VALID_ROUTES))
 
@@ -102,6 +104,9 @@ VALID_REFINE_KEYS = {
         'contactAddress', 'countryId', 'userId', 'referrerId', 'name',
         'nameOrId', 'town', 'privatePhone', 'billingAddressId',
         'deliveryAddressId', 'tagIds'
+    ],
+    'property': [
+        'propertyId'
     ]
 }
 


### PR DESCRIPTION
The function plenty_api_get_property_selections was calling query before
it was assigned, Instead of calling query call None since there is no
already existing query for the function.

Signed-off-by: Jan <jan.sallermann@panasiam.de>