### PR TITLE
Add Amazon Product Types PIM Rest Endpoint 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ images/
 playground/
 
 # CONFIG FILES
-mensa_config.py
-app/api/data/
-app/api/dummydata/speiseplan
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -124,9 +121,6 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
 
 # Rope project settings
 .ropeproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,143 @@
-# Temporary Python files
-*.pyc
-*.egg-info
+.drafts
+config.json
 __pycache__
-.ipynb_checkpoints
-setup.py
+
+.vscode
+.secrets.json
+
+# CUSTOM FILES!
+
+images/
+playground/
+
+# CONFIG FILES
+mensa_config.py
+app/api/data/
+app/api/dummydata/speiseplan
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.idea/
+# C extensions
+*.so
+.DS_Store
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+000*.json
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
 pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
-# Temporary OS files
-Icon*
-
-# Temporary virtual environment files
-/.cache/
-/.venv/
-
-# Temporary server files
-.env
-*.pid
-
-# Generated documentation
-/docs/gen/
-/docs/apidocs/
-/site/
-/*.html
-/docs/*.png
-
-# Google Drive
-*.gdoc
-*.gsheet
-*.gslides
-*.gdraw
-
-# Testing and coverage results
-/.coverage
-/.coverage.*
-/htmlcov/
-
-# Build and release directories
-/build/
-/dist/
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
 *.spec
 
-# Sublime Text
-*.sublime-workspace
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
 
-# Eclipse
-.settings
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
 
-# Custom
-Session.vim
-pytest.ini
-.pylint.ini
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/docs/API_reference.md
+++ b/docs/API_reference.md
@@ -34,6 +34,8 @@
     + [Plenty BI related data](#get-bi-section)
 		* [get BI rawfile-list](#get-bi)
 		* [dump BI rawfiles]  (#dump-bi)
+    + [Plenty PIM related data](#get-pim-section)
+        * [get amazon_product_types](#get-amazon-product-types)
 - [POST-Requests](#post-requests)
     + [Item related data](#post-items-section)
         * [post image avaialability](#post-image-availability)
@@ -632,6 +634,16 @@ If the directory doesn't exist it will be created automatically.
 [*Output format*]:
 
 This method returns the list of paths to the downloaded files.
+
+#### Plenty PIM related data <a name='get-pim-section'></a>
+
+##### plenty_api_get_amazon_product_types <a name='get-amazon-product-types'></a>
+
+GET '​/rest​/pim​/amazon-product-types'
+
+Gets a list of all amazon product types. Use `plenty_api_get_amazon_product_types` to to retrieve the list.
+More information in the [PlentyMarkets documentation](https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/Pim/get_rest_pim_amazon_product_types).
+
 
 ### POST requests: <a name='post-requests'></a>
 

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -1313,13 +1313,12 @@ class PlentyApi():
     def plenty_api_get_amazon_product_types(self):
         """
         Get a list of all available Amazon product types.
-        https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/Pim/get_rest_pim_amazon_product_types
+
         Return:
                         [JSON(Dict) / DataFrame] <= self.data_format
         """
-        domain = 'pim' # pim is the REST Route not the domain
-        path = '/amazon-product-types' # path in this case is the endpoint
-        return self.__plenty_api_generic_get(domain='pim', path=path)
+        return self.__plenty_api_generic_get(domain='pim',
+                                             path='/amazon-product-types')
 
 # POST REQUESTS
 

--- a/plenty_api/api.py
+++ b/plenty_api/api.py
@@ -89,6 +89,8 @@ class PlentyApi():
         **plenty_api_dump_bi_raw_file**
 
         **plenty_api_get_bi_raw_files**
+        
+        **plenty_api_get_amazon_product_types**
 
         POST REQUESTS
         **plenty_api_set_image_availability**
@@ -1307,6 +1309,17 @@ class PlentyApi():
 
         return utils.summarize_shipment_packages(
             response=package_responses, mode=mode)
+
+    def plenty_api_get_amazon_product_types(self):
+        """
+        Get a list of all available Amazon product types.
+        https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/Pim/get_rest_pim_amazon_product_types
+        Return:
+                        [JSON(Dict) / DataFrame] <= self.data_format
+        """
+        domain = 'pim' # pim is the REST Route not the domain
+        path = '/amazon-product-types' # path in this case is the endpoint
+        return self.__plenty_api_generic_get(domain='pim', path=path)
 
 # POST REQUESTS
 

--- a/plenty_api/constants.py
+++ b/plenty_api/constants.py
@@ -38,7 +38,8 @@ VALID_DOMAINS = [
     'warehouses',
     'property',
     'v2property',
-    'bi_raw'
+    'bi_raw',
+    'pim',
 ]
 VALID_ROUTES = [
     '/rest/items/attributes',
@@ -56,7 +57,8 @@ VALID_ROUTES = [
     '/rest/stockmanagement/warehouses',
     '/rest/properties',
     '/rest/v2/properties',
-    '/rest/bi/raw-data'
+    '/rest/bi/raw-data',
+    '/rest/pim',
 ]
 DOMAIN_ROUTE_MAP = dict(zip(VALID_DOMAINS, VALID_ROUTES))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "plenty_api"
-version = "0.2.10.1"
+version = "0.2.11.0"
 description = "Interface for the PlentyMarkets API."
 
 license = "GPLv3"


### PR DESCRIPTION
- Added plenty_api_get_amazon_product_types Rest endpoint, for fetching pim amazon_product_types via plenty REST API
> in connection added 'pim' to constants routes and domain register.
> in connection added related parts to documentation

[PIM GET ​/rest​/pim​/amazon-product-types DOCU](https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html#/Pim/get_rest_pim_amazon_product_types)

- Modified Git ignore for completion